### PR TITLE
release: v1.7.1

### DIFF
--- a/apps/parable-bloom-site/CHANGELOG.md
+++ b/apps/parable-bloom-site/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1 (2026-07-15)
+
+This was a version bump only for parable-bloom-site to align it with other projects, there were no code changes.
+
 ## 0.4.0 (2026-06-23)
 
 ### 🚀 Features

--- a/apps/parable-bloom-site/package.json
+++ b/apps/parable-bloom-site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parable-bloom-site",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "scripts": {
     "build": "next build",
     "dev": "next dev --port 4201",

--- a/apps/parable-bloom/CHANGELOG.md
+++ b/apps/parable-bloom/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.7.1 (2026-07-15)
+
+This was a version bump only for parable-bloom to align it with other projects, there were no code changes.
+
 ## 1.7.0 (2026-06-23)
 
 ### 🚀 Features

--- a/apps/parable-bloom/package.json
+++ b/apps/parable-bloom/package.json
@@ -1,4 +1,4 @@
 {
   "name": "parable-bloom",
-  "version": "1.7.0"
+  "version": "1.7.1"
 }

--- a/apps/parable-bloom/pubspec.yaml
+++ b/apps/parable-bloom/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.7.0+16
+version: 1.7.1+17
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/tools/level-builder/CHANGELOG.md
+++ b/tools/level-builder/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.7.1 (2026-07-15)
+
+This was a version bump only for level-builder to align it with other projects, there were no code changes.
+
 ## 1.7.0 (2026-06-23)
 
 ### 🚀 Features

--- a/tools/level-builder/package.json
+++ b/tools/level-builder/package.json
@@ -1,4 +1,4 @@
 {
   "name": "level-builder",
-  "version": "1.7.0"
+  "version": "1.7.1"
 }


### PR DESCRIPTION
Automated release sync for v1.7.1. 
               
               This PR contains the version bump and changelog updates that couldn't be pushed directly to `main` due to branch protection rules.
               
               **Note for Squash Mergers:** The git tag (`v1.7.1`) is already pushed and points to the commit in this branch. Even after squash merging and branch deletion, the tag will remain in the repository history.