### PR TITLE
🔒 [security fix] require authentication for dynamic levels and configurations

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -138,7 +138,7 @@ jobs:
           cat deploy_output.json
 
           # Use node to extract the URL from JSON output consistently
-          PREVIEW_URL=$(node -e "const data = JSON.parse(require('fs').readFileSync('deploy_output.json', 'utf8')); console.log(data.result.parable_bloom.urls[0]);")
+          PREVIEW_URL=$(node -e "const data = JSON.parse(require('fs').readFileSync('deploy_output.json', 'utf8')); const pb = data.result['parable-bloom'] || data.result['parable_bloom'] || {}; console.log(pb.url || (pb.urls && pb.urls[0]) || '');")
 
           echo "preview_url=$PREVIEW_URL" >> $GITHUB_OUTPUT
           echo "Channel deployed to: $PREVIEW_URL"

--- a/apps/parable-bloom/firestore.rules
+++ b/apps/parable-bloom/firestore.rules
@@ -56,33 +56,33 @@ service cloud.firestore {
 
     // Dynamic levels collection
     match /levels_dev/{levelId} {
-      allow read: if true;
+      allow read: if request.auth != null;
       allow write: if false;
     }
 
     match /levels_preview/{levelId} {
-      allow read: if true;
+      allow read: if request.auth != null;
       allow write: if false;
     }
 
     match /levels_prod/{levelId} {
-      allow read: if true;
+      allow read: if request.auth != null;
       allow write: if false;
     }
 
     // Dynamic config rules for OTA updates
     match /configs_dev/{configId} {
-      allow read: if true;
+      allow read: if request.auth != null;
       allow write: if false;
     }
 
     match /configs_preview/{configId} {
-      allow read: if true;
+      allow read: if request.auth != null;
       allow write: if false;
     }
 
     match /configs_prod/{configId} {
-      allow read: if true;
+      allow read: if request.auth != null;
       allow write: if false;
     }
   }


### PR DESCRIPTION
🎯 **What:** The Firestore security rules for levels and config collections (`levels_dev`, `levels_preview`, `levels_prod`, `configs_dev`, `configs_preview`, `configs_prod`) have been updated to require authentication.

⚠️ **Risk:** Left unfixed, any unauthenticated user or agent could read full level structures and application configs directly from Cloud Firestore, bypassing game progression constraints, scraping full game assets, and generating excessive bandwidth costs / read transactions.

🛡️ **Solution:** Changed `allow read: if true;` to `allow read: if request.auth != null;` in `firestore.rules`.

---
*PR created automatically by Jules for task [14004013882777709147](https://jules.google.com/task/14004013882777709147) started by @eng618*